### PR TITLE
BugFix: Some previous coding errors

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3272,7 +3272,7 @@ void T2DMap::slot_setArea()
 
     int newAreaId = arealist_combobox->itemData( arealist_combobox->currentIndex() ).toInt();
     mMultiRect = QRect(0,0,0,0);
-    uint maxRoomIndex = mMultiSelectionList.size() - 1;
+    int maxRoomIndex = mMultiSelectionList.size() - 1;
     for( int j = 0; j <= maxRoomIndex; j++ ) {
         if( j < maxRoomIndex ) {
             mpMap->setRoomArea( mMultiSelectionList.at(j), newAreaId, true );

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -585,7 +585,7 @@ const QMultiMap<int, QPair<QString, int> > TArea::getAreaExitRoomData() const
             case DIR_OUT:       exitData.first = QString("out");           break;
             case DIR_OTHER:     roomsWithOtherAreaSpecialExits.insert(itAreaExit.key());   break;
             default:
-                qWarning("TArea::getAreaExitRoomData() Warning: unrecognised exit code %1 found for exit from room %2 to room %3.",
+                qWarning("TArea::getAreaExitRoomData() Warning: unrecognised exit code %i found for exit from room %i to room %i.",
                          itAreaExit.value().second, itAreaExit.key(), itAreaExit.value().first );
         }
         if( ! exitData.first.isEmpty() ) {

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -56,7 +56,6 @@ public:
     QList<int> getCollisionNodes();
     QList<int> getRoomsByPosition( int x, int y, int z );
     QMap<int, QMap<int, QMultiMap<int, int> > > koordinatenSystem();
-    bool mIsDirty;
 
 
     QList<int> rooms;                       // rooms of this area
@@ -79,6 +78,8 @@ public:
     bool isZone;
     int zoneAreaRef;
     TRoomDB * mpRoomDB;
+    bool mIsDirty;
+
 
 private:
     TArea(){qFatal("FATAL: illegal default constructor use of TArea()");};

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8400,7 +8400,7 @@ int TLuaInterpreter::resetRoomArea( lua_State * L )
         lua_pushstring( L, tr( "resetRoomArea: bad argument #1 value (room Id must exist)." ).toUtf8().constData() );
         return 2;
     }
-    else if ( pHost ) {
+    else {
        lua_pushboolean( L, pHost->mpMap->setRoomArea( id, -1, false ) );
        return 1;
     }

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -232,7 +232,7 @@ bool TRoom::setArea( int areaID, bool isToDeferAreaRelatedRecalculations )
     pA->addRoom( id );
 
     dirtyAreas.insert( pA );
-    pA->mIsDirty;
+    pA->mIsDirty = true;
 
     if( ! isToDeferAreaRelatedRecalculations ) {
         QSetIterator<TArea *> itpArea = dirtyAreas;


### PR DESCRIPTION
* T2DMap::slot_setArea(): used a uint where I should have used an int as a
  method I called can return a -1 in some cases.

* TArea::getAreaExitRoomData(): a qWarning() in a debugging line I had
  used the wrong type (%1,%2,...) of format string argument characters when
  I should of used (%i or %s)...

* (bool)TArea::mIsDirty: was put in wrong block of lines in header

* TLuaInterpreter::resetRoomArea(): put in a spurious test that had already
  been covered by prior code.

* (boo)TRoom::setArea(int, bool): by not assigning a value to the
  TArea::isDirty variable the code was ineffective and might cause a bug
  that it was designed to prevent.

Signed-off-by: Stephen Lyons <stephen@ripley.lyonsnet>